### PR TITLE
Fixed problem with repository_dispatch on github workflow

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function generateSlackMessage(text) {
     if (github.context.payload.head_commit) {
         commitURL = github.context.payload.head_commit.url;
     } else {
-        commitURL = `${github.context.payload.repository.html_url}/commit/${github.context.sha}`
+        commitURL = `${github.context.payload.repository.html_url}/commit/${github.context.sha}`;
     }
     return {
         channel: process.env.SLACK_CHANNEL,

--- a/index.js
+++ b/index.js
@@ -29,7 +29,12 @@ function getColor(status) {
 function generateSlackMessage(text) {
     const actor = github.context.actor;
     const status = process.env.STATUS || '';
-    const commitURL = github.context.payload.head_commit.url;
+    let commitURL = '';
+    if (github.context.payload.head_commit) {
+        commitURL = github.context.payload.head_commit.url;
+    } else {
+        commitURL = `${github.context.payload.repository.html_url}/commit/${github.context.sha}`
+    }
     return {
         channel: process.env.SLACK_CHANNEL,
         username: process.env.BOT_USERNAME,


### PR DESCRIPTION
Hi @raulanatol, how are you? I have detected a problem when using this Github Action when the github workflow is triggered from a repository_dispatch, giving this error in those cases:

`Cannot read properties of undefined (reading 'url')`

This happens because head_commit is undefined in that case, this doesn't happen if triggered from a push, pull-request, etc...
So I propose this change to correct this case by forming the commit url in another way.

Thank you and a hug sir