### PR TITLE
Error when get commit message

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,10 +30,13 @@ function generateSlackMessage(text) {
     const actor = github.context.actor;
     const status = process.env.STATUS || '';
     let commitURL = '';
+    let commitMessage = '';
     if (github.context.payload.head_commit) {
         commitURL = github.context.payload.head_commit.url;
+        commitMessage = github.context.payload.head_commit.message;
     } else {
         commitURL = `${github.context.payload.repository.html_url}/commit/${github.context.sha}`;
+        commitMessage = github.context.payload.action;
     }
     return {
         channel: process.env.SLACK_CHANNEL,
@@ -51,7 +54,7 @@ function generateSlackMessage(text) {
                 "fields": [
                     {
                         "title": "Commit Message",
-                        "value": github.context.payload.head_commit.message,
+                        "value": commitMessage,
                         "short": false
                     },
                     {


### PR DESCRIPTION
Hi @raulanatol, sorry, :facepalm: in the previous PR I forgot that happen same error when you try get commit message if don't exists head_commit when trigger github workflow from repository_dispatch. I don't see a way to get the commit message in that case so I use the action of the payload.